### PR TITLE
Use better time format

### DIFF
--- a/app/src/main/java/com/mzhang/cleantimer/Common.java
+++ b/app/src/main/java/com/mzhang/cleantimer/Common.java
@@ -1,0 +1,9 @@
+package com.mzhang.cleantimer;
+
+public class Common {
+    public static String formatTime(int totalMillis) {
+        int mins = totalMillis / 60000;
+        double secs = (double)(totalMillis % 60000) / 1000;
+        return String.format("%02d", mins) + ":" + String.format("%06.3f", secs);
+    }
+}

--- a/app/src/main/java/com/mzhang/cleantimer/MainActivity.java
+++ b/app/src/main/java/com/mzhang/cleantimer/MainActivity.java
@@ -70,7 +70,7 @@ public class MainActivity extends AppCompatActivity {
         public void run() {
             recorded = (System.nanoTime() - startTime) / 1000000;
             time = (int) recorded;
-            timer.setText(formatTime(time));
+            timer.setText(Common.formatTime(time));
             handler.postDelayed(this, 0);
         }
     };
@@ -84,7 +84,7 @@ public class MainActivity extends AppCompatActivity {
                 startMainTimer();
                 handler.removeCallbacks(updateInspectTimer);
             } else {
-                timer.setText(formatTime(time));
+                timer.setText(Common.formatTime(time));
                 handler.postDelayed(this, 0);
             }
         }
@@ -123,15 +123,6 @@ public class MainActivity extends AppCompatActivity {
         return textBox;
     }
 
-    String formatTime(int input) {
-        int secs = (int) (input / 1000);
-        int mins = secs / 60;
-        secs %= 60;
-        int mills = (int) (input % 1000);
-        return String.format("%02d", mins) + ":" + String.format("%02d", secs)
-                + ":" + String.format("%03d", mills);
-    }
-
     int listAverage(List<Integer> inputList) {
         double sum = 0;
         for (Integer value : inputList) {
@@ -149,10 +140,10 @@ public class MainActivity extends AppCompatActivity {
         List<Integer> lastFiveList = solvesList.subList(Math.max(solvesList.size() - 5, 0), solvesList.size());
 
         if (lastFiveList.size() > 0) {
-            lastFiveAverage.setText(formatTime(listAverage(lastFiveList)));
+            lastFiveAverage.setText(Common.formatTime(listAverage(lastFiveList)));
             String toPrint = "";
             for (int i = 0; i < lastFiveList.size(); i++) {
-                toPrint += formatTime((lastFiveList.get(i))) + "\n";
+                toPrint += Common.formatTime((lastFiveList.get(i))) + "\n";
                 displayedSolves.setText(toPrint);
             }
         } else {

--- a/app/src/main/java/com/mzhang/cleantimer/stats.java
+++ b/app/src/main/java/com/mzhang/cleantimer/stats.java
@@ -26,16 +26,6 @@ public class stats extends AppCompatActivity {
 
     GestureDetector detector;
 
-
-    String formatTime(int input) {
-        int secs = (int) (input / 1000);
-        int mins = secs / 60;
-        secs %= 60;
-        int mills = (int) (input % 1000);
-        return String.format("%02d", mins) + ":" + String.format("%02d", secs)
-                + ":" + String.format("%03d", mills);
-    }
-
     void saveSolvesList(ArrayList<Integer> solvesList) {
         SharedPreferences pref = getSharedPreferences("com.mzhang.cleantimer.solvesList", Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = pref.edit();
@@ -85,7 +75,7 @@ public class stats extends AppCompatActivity {
 
     String returnAverageOf(List<Integer> inputList, int range) {
         List sublist = inputList.subList(Math.max(inputList.size() - range, 0), inputList.size());
-        return formatTime(listAverage(sublist));
+        return Common.formatTime(listAverage(sublist));
     }
 
     @Override
@@ -151,13 +141,13 @@ public class stats extends AppCompatActivity {
         averageof5value.setText(returnAverageOf(solvesList, 5));
         averageof25value.setText(returnAverageOf(solvesList, 25));
         averageof100value.setText(returnAverageOf(solvesList, 100));
-        averageofcareervalue.setText(formatTime(listAverage(solvesList)));
+        averageofcareervalue.setText(Common.formatTime(listAverage(solvesList)));
 
         RecyclerView recyclerView = findViewById(R.id.recyclerView);
 
         final ArrayList<String> solvesListString = new ArrayList<String>();
         for (int i=0; i < solvesList.size(); i++) {
-            solvesListString.add(formatTime(solvesList.get(i)));
+            solvesListString.add(Common.formatTime(solvesList.get(i)));
         }
 
         SharedPreferences solvesMasterList = getSharedPreferences("com.mzhang.cleantimer.solvesList", Context.MODE_PRIVATE);
@@ -183,7 +173,7 @@ public class stats extends AppCompatActivity {
                 averageof5value.setText(returnAverageOf(solvesList, 5));
                 averageof25value.setText(returnAverageOf(solvesList, 25));
                 averageof100value.setText(returnAverageOf(solvesList, 100));
-                averageofcareervalue.setText(formatTime(listAverage(solvesList)));
+                averageofcareervalue.setText(Common.formatTime(listAverage(solvesList)));
             }
         });
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Clean Timer</string>
-    <string name="_00_00_000">00:00:000</string>
+    <string name="_00_00_000">00:00.000</string>
     <string name="averageOf5">Average of 5</string>
     <string name="averageOf25">Average of 25</string>
     <string name="averageOf100">Average of 100</string>


### PR DESCRIPTION
Before the time format was 12:34:567 meaning 12 minutes and 34.567
seconds. It's incorrect to separate the whole seconds and the fractional
part with a colon. Now the format 12:34.567 is used.

Also the method formatTime now only exists once in the project in
Common.java and both MainActivity.java and stats.java use it.